### PR TITLE
fix: make logger.Backend can be implemented, change close() to Close()

### DIFF
--- a/logger/file.go
+++ b/logger/file.go
@@ -56,7 +56,7 @@ func (self *syncBuffer) write(b []byte) {
 
 type FileBackend struct {
 	mu            sync.Mutex
-	dir           string //directory for log files
+	dir           string // directory for log files
 	files         [numSeverity]syncBuffer
 	flushInterval time.Duration
 	rotateNum     int
@@ -78,7 +78,7 @@ func (self *FileBackend) Flush() {
 
 }
 
-func (self *FileBackend) close() {
+func (self *FileBackend) Close() {
 	self.Flush()
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -34,7 +34,7 @@ const (
 
 type Backend interface {
 	Log(s Severity, msg []byte)
-	close()
+	Close()
 }
 
 type stdBackend struct{}
@@ -43,7 +43,7 @@ func (self *stdBackend) Log(s Severity, msg []byte) {
 	os.Stdout.Write(msg)
 }
 
-func (self *stdBackend) close() {}
+func (self *stdBackend) Close() {}
 
 type Logger struct {
 	s       Severity
@@ -284,7 +284,7 @@ func (l *Logger) SetSeverity(level interface{}) {
 
 func (l *Logger) Close() {
 	if l.backend != nil {
-		l.backend.close()
+		l.backend.Close()
 	}
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -25,7 +25,7 @@ func TestDefaultFileBackend(t *testing.T) {
 	conf.FileName = "/tmp/dlog-test/defaultFileBackend"
 	conf.FileRotateSize = 1024 * 1024 * 1024
 	conf.FileRotateCount = 20
-	//conf.FileFlushDuration = time.Second * 1
+	// conf.FileFlushDuration = time.Second * 1
 
 	Init(conf)
 	Info("Info")
@@ -46,11 +46,11 @@ func TestFileBackend(t *testing.T) {
 	conf.FileName = "/tmp/dlog-test/fileBackend"
 	conf.FileRotateSize = 1024 * 1024 * 1024
 	conf.FileRotateCount = 20
-	//conf.FileFlushDuration = time.Second * 1
+	// conf.FileFlushDuration = time.Second * 1
 
 	log, err := NewLoggerFromConfig(conf)
 	if err != nil {
-		fmt.Println("err when call NewLoggerFromConfig: [%s]", err.Error())
+		fmt.Printf("err when call NewLoggerFromConfig: [%s]\n", err.Error())
 		return
 	}
 
@@ -82,7 +82,7 @@ func TestBothFileBackend(t *testing.T) {
 	conf1.FileRotateCount = 20
 	log1, err := NewLoggerFromConfig(conf1)
 	if err != nil {
-		fmt.Println("err when call NewLoggerFromConfig: [%s]", err.Error())
+		fmt.Printf("err when call NewLoggerFromConfig: [%s]\n", err.Error())
 		return
 	}
 
@@ -94,7 +94,7 @@ func TestBothFileBackend(t *testing.T) {
 	conf2.FileRotateCount = 20
 	log2, err := NewLoggerFromConfig(conf2)
 	if err != nil {
-		fmt.Println("err when call NewLoggerFromConfig: [%s]", err.Error())
+		fmt.Printf("err when call NewLoggerFromConfig: [%s]\n", err.Error())
 		return
 	}
 

--- a/logger/multi.go
+++ b/logger/multi.go
@@ -16,8 +16,8 @@ func (self *multiBackend) Log(s Severity, msg []byte) {
 	}
 }
 
-func (self *multiBackend) close() {
+func (self *multiBackend) Close() {
 	for _, be := range self.bes {
-		be.close()
+		be.Close()
 	}
 }

--- a/logger/syslog_unix.go
+++ b/logger/syslog_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || openbsd || solaris
 // +build linux darwin freebsd openbsd solaris
 
 package logger
@@ -75,7 +76,7 @@ func (self *syslogBackend) Log(s Severity, msg []byte) {
 	}
 }
 
-func (self *syslogBackend) close() {
+func (self *syslogBackend) Close() {
 	for i := 0; i < numSeverity; i++ {
 		self.writer[i].Close()
 	}


### PR DESCRIPTION
Backend的实现如下，由于“close”是小写，私有的，外部包，永远无法自定义实现Backend
```go
type Backend interface {
	Log(s Severity, msg []byte)
	close()
}
```
需要修改成如下：
```go
type Backend interface {
	Log(s Severity, msg []byte)
	Close()
}
```
影响范围，只有当前pkg项目下的代码，外部引用该pkg，无感知，不会影响其他项目