### PR TITLE
feat: add i18n support for errorx.Bomb and errorx.Dangerous

### DIFF
--- a/errorx/errorx.go
+++ b/errorx/errorx.go
@@ -2,6 +2,9 @@ package errorx
 
 import (
 	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/toolkits/pkg/i18n"
 )
 
 type PageError struct {
@@ -21,6 +24,11 @@ func Bomb(code int, format string, a ...interface{}) {
 	panic(PageError{Code: code, Message: fmt.Sprintf(format, a...)})
 }
 
+func BombWithI18n(ctx *gin.Context, code int, format string, a ...interface{}) {
+	lang := ctx.GetHeader("X-Language")
+	panic(PageError{Code: code, Message: i18n.Sprintf(lang, format, a...)})
+}
+
 func Dangerous(v interface{}, code ...int) {
 	if v == nil {
 		return
@@ -38,5 +46,26 @@ func Dangerous(v interface{}, code ...int) {
 		}
 	case error:
 		panic(PageError{Code: c, Message: t.Error()})
+	}
+}
+
+func DangerousWithI18n(ctx *gin.Context, v interface{}, code ...int) {
+	if v == nil {
+		return
+	}
+
+	c := 200
+	if len(code) > 0 {
+		c = code[0]
+	}
+
+	lang := ctx.GetHeader("X-Language")
+	switch t := v.(type) {
+	case string:
+		if t != "" {
+			panic(PageError{Code: c, Message: i18n.Sprintf(lang, t)})
+		}
+	case error:
+		panic(PageError{Code: c, Message: i18n.Sprintf(lang, t.Error())})
 	}
 }


### PR DESCRIPTION
I was trying to create an business group using Flashcat. When submitting the form without any teams specified,  the returning error message would be "members empty" in English, even if the request language is specified as `zh_CN` in header `X-Language`.

<img width="1030" alt="failing-precheck" src="https://github.com/user-attachments/assets/a3ae3ab2-1bbd-41d3-890d-425df71ad700">

**How this problem was discovered:**
If the HTTP input element for `Team` is expanded as default, frontend will do a precheck when the submit button is hit, and renders `Business group team is required` under the HTTP input element. (By the way, this message is multi-languaged, which is supported by frontend. 

<img width="700" alt="frontend-precheck-zh_cn" src="https://github.com/user-attachments/assets/36a0b3dd-5227-45d4-a271-ed590cf6a930">

<img width="699" alt="frontend-precheck" src="https://github.com/user-attachments/assets/75cd8010-2aae-4ac7-970a-0c7eb3230eff">


This precheck is obviously done in frontend and has no relation with backend.) However, when the user choose not to fill in any team but to hide the input and submit the form, the frontend precheck will fail, and a global error message would pop up after backend responds to the request with error message `members empty` without the process of i18n.

Actually there are two bugs in the logic of creating a new business group:
1. In frontend: The precheck before submitting the request would fail if the user simply hides the input for `Team`.
2. In backend: There isn't any i18n support for `errorx.Bomb` and `errorx.Dangerous`. Only i18n support for `Render.Message` is provided.

To make those translations for error messages in `i18n.go` actually work, I wrote two new functions with `gin.Context` as  additional parameter, to transform the message into related language version. Considering hundreds of old `errorx.Bomb` and `errorx.Dangerous` are used, a full replacement for two methods are unrealistic, but callers can choose to use these two new functions to make translations for error messages in i18n really work, from now on.

